### PR TITLE
Workaround for UUIDs in item nbt tags

### DIFF
--- a/lib/src/basic/types/item.dart
+++ b/lib/src/basic/types/item.dart
@@ -206,7 +206,8 @@ class Item {
   String getGiveNotation({bool withDamage = true}) {
     var result = type;
     if (tag != null && tag!.isNotEmpty) {
-      result += gson.encode(tag);
+      final nbt = gson.encode(tag);
+      result += _fixUuidArray(nbt); 
     }
     result += ' ';
     if (count != null) result += count.toString();
@@ -235,7 +236,20 @@ class Item {
   }
 
   String getNbt() {
-    return gson.encode(getMap());
+    final nbt = gson.encode(getMap());
+    return _fixUuidArray(nbt);
+  }
+
+  /// Fixes the int array representation of UUIDs
+  /// to be recognized by Minecraft.
+  /// 
+  /// [1,2,3,4] -> [I;1,2,3,4]
+  /// 
+  /// The resulting nbt is not a valid json anymore! 
+  String _fixUuidArray(String nbt) {
+    // Matches 'UUID:[w,v,x,y]' occurances
+    var regex = RegExp(r'(?<=UUID\s*:\s*)\[(\d+,\d+,\d+,\d+)\]');
+    return nbt.replaceAllMapped(regex, (match) => "[I;${match[1]}]");
   }
 
   Item copyWith({

--- a/test/item_test.dart
+++ b/test/item_test.dart
@@ -1,0 +1,35 @@
+import 'package:objd/core.dart';
+import 'package:test/test.dart';
+
+import 'test_widget.dart';
+
+void main() {
+  group('Item', () {
+    builder('UUID in getNbt', () {
+      final item = Item(
+        Items.crafting_table,
+        nbt: {
+          'UUID': [11, 22, 33, 44]
+        },
+      );
+      expect(
+        item.getNbt(),
+        '{id:"minecraft:crafting_table",tag:{UUID:[I;11,22,33,44]}}',
+      );
+    });
+
+    builder('UUID in getGiveNotation', () {
+      final item = Item(
+        Items.furnace,
+        count: 3,
+        nbt: {
+          'UUID': [11, 22, 33, 44]
+        },
+      );
+      expect(
+        item.getGiveNotation(),
+        'minecraft:furnace{UUID:[I;11,22,33,44]} 3',
+      );
+    });
+  });
+}


### PR DESCRIPTION
This fixes an issue with int array representation of UUIDs in nbt tags for items.

Minecraft does not used the standard array format for UUIDs but presumably expects a marker at the beginning.
```
UUID:[11,22,33,44] // not recognized by Minecraft
UUID:[I;11,22,33,44] // this however is
```
To solve this issue a little post processing step has been introduced which inserts the expected `I;` for every UUID in int array representation.