### PR TITLE
fix: remove file extension from load/tick tag

### DIFF
--- a/lib/src/build/build.dart
+++ b/lib/src/build/build.dart
@@ -107,12 +107,12 @@ Map<String, String> _getFiles(BuildProject prj, GenOptions options) {
           // add load and main
           if (pack.load != null && pack.load!.isNotEmpty && pack.isGenLoad) {
             loadJson['values'].add(
-              '${pack.name}:${pack.load!}',
+              '${pack.name}:${pack.load!.toString(false)}',
             );
           }
           if (pack.main != null && pack.main!.isNotEmpty && pack.isGenMain) {
             tickJson['values'].add(
-              '${pack.name}:${pack.main!}',
+              '${pack.name}:${pack.main!.toString(false)}',
             );
           }
         }


### PR DESCRIPTION
ObjD currently generates `{"values":["valocraft:load.mcfunction"]}` instead of `{"values":["valocraft:load"]}`.  
This makes both the load and tick functions do nothing.  
This PR fixes this.
